### PR TITLE
Feature omit particular entries

### DIFF
--- a/dl.py
+++ b/dl.py
@@ -44,7 +44,9 @@ def help():
 
 def list_dl(doc):
     curLink = 0
-    lines = open(doc).readlines()       #reads the lines of the given document and store them in the list "lines"
+    tmp_list = open(doc).readlines()
+    fixed_list = [el for el in tmp_list if not el.startswith('#')]
+    lines = fixed_list      #reads the lines of the given document and store them in the list "lines"
     for link in lines:                  #calls the download function for every link in the document
         curLink +=1
         print("Download %s / "%curLink + str(len(lines)))

--- a/dl.py
+++ b/dl.py
@@ -76,8 +76,7 @@ def download(URL):
         url = html_page.text[i0+L:i1]
         return download(url)
 
-    name_find = soup.find('meta', attrs={"name":"og:title"})
-    name = name_find["content"]
+    name = soup.find('title').string
     name = name.replace(" ","_")
     print("Name of file: " + name)
 


### PR DESCRIPTION
Temporary solution which can be useful to disable individual links just by add "#" in front of them (or point out which one was downloaded). 

I created this before I figured out that links are valid but site scraped by BeautifulSoup missing some tags (some links just didn't work correctly). But I find it useful piece of code anyways.