### PR TITLE
updated requirements as base64 is not needed. closes #41

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ requests
 beautifulsoup4
 yt-dlp
 wget
-base64


### PR DESCRIPTION
couldn't download the script as package 'base64' was listed in requirements.txt, but base64 is a native python package.

removed this package from requirements.txt